### PR TITLE
Fixes for Xcode 11 beta 4

### DIFF
--- a/CxVision/Source/Configuration.swift
+++ b/CxVision/Source/Configuration.swift
@@ -7,6 +7,7 @@
 //
 
 import Vision
+import CoreImage
 
 /// A struct for holding onto a configuration function to be applied to a `VNRequest`
 ///

--- a/CxVision/Source/VNImageRequestHandler+Cx.swift
+++ b/CxVision/Source/VNImageRequestHandler+Cx.swift
@@ -15,7 +15,7 @@ enum VisionError: Error {
 
 public extension VNImageRequestHandler {
   /// Creates a publisher based on the provided Configuration
-  /// - Parameter configuration: Configuration<A: VNRequest, B: VNObservation>. Default implementation provided in cases where the publisher is assigned directly.
+  /// - Parameter configuration: Configuration<A: VNRequest, B: VNObservation>. 
   func publisher<Request: VNRequest, Observation: VNObservation>(for configuration: Configuration<Request, Observation>) -> AnyPublisher<[Observation], Error> {
     var requests = [VNRequest]()
     
@@ -34,7 +34,7 @@ public extension VNImageRequestHandler {
       requests.append(visionRequest)
     }
     
-    let performPublisher = Future { resultFn in resultFn(Result { try self.perform(requests) }) }
+    let performPublisher = Future { promise in promise(Result { try self.perform(requests) }) }
     
     return performPublisher
       .combineLatest(visionFuture)
@@ -67,7 +67,7 @@ public extension VNImageRequestHandler {
       }
     )
       
-    let performPublisher = Publishers.Once<(), Error>(Result { try self.perform(requests) })
+    let performPublisher = Future { promise in promise(Result { try self.perform(requests) }) }
     
     return performPublisher
       .combineLatest(futures)

--- a/CxVisionTests/CxVisionTests.swift
+++ b/CxVisionTests/CxVisionTests.swift
@@ -24,6 +24,7 @@ class CxVisionTests: XCTestCase {
     let expectation = XCTestExpectation(description: "ObservationExpectation")
     _ = VNImageRequestHandler(data: getImage(named: "image_sample.jpg").pngData()!, options: [:])
       .publisher(for: SimpleConfiguration<VNRecognizeTextRequest> { request in request.recognitionLevel = .fast })
+      .assertNoFailure()
       .sink { _ in
         expectation.fulfill()
       }
@@ -36,6 +37,7 @@ class CxVisionTests: XCTestCase {
     let elevenLines = XCTestExpectation(description: "Eleven lines")
     _ = VNImageRequestHandler(data: getImage(named: "image_sample.jpg").pngData()!, options: [:])
       .publisher(for: Configuration<VNRecognizeTextRequest, VNRecognizedTextObservation> { request in request.recognitionLevel = .fast })
+      .assertNoFailure()
       .sink { observations in
         XCTAssertEqual(observations.count, 1)
         oneLine.fulfill()
@@ -43,6 +45,7 @@ class CxVisionTests: XCTestCase {
     
     _ = VNImageRequestHandler(data: getImage(named: "Lenore3.png").pngData()!, options: [:])
       .publisher(for: Configuration<VNRecognizeTextRequest, VNRecognizedTextObservation> { request in request.recognitionLevel = .fast } )
+      .assertNoFailure()
       .sink { observations in
         XCTAssertEqual(observations.count, 11)
         elevenLines.fulfill()
@@ -55,10 +58,11 @@ class CxVisionTests: XCTestCase {
     let expectation = XCTestExpectation(description: "ObservationExpectation")
     _ = VNImageRequestHandler(data: getImage(named: "image_sample.jpg").pngData()!, options: [:])
       .publisher(for: Configuration<VNRecognizeTextRequest, VNRecognizedTextObservation> { request in request.recognitionLevel = .fast } )
+      .assertNoFailure()
       .sink { observations in
         XCTAssertEqual(observations.first!.topCandidates(1).first!.string.trimmingCharacters(in: .whitespacesAndNewlines), "1234567890")
         expectation.fulfill()
-    }
+      }
     
     wait(for: [expectation], timeout: 10)
   }


### PR DESCRIPTION
Publishers.Once was removed, replaced with Future.
CIImage no longer appears to be part of Foundation (which is implicitly imported when importing Vision), so CoreImage was added to the list of imports in Configuration.swift.
Fixed tests.